### PR TITLE
SSL cert validation for web sockets

### DIFF
--- a/IntelliCenterControl/IntelliCenterControl/Services/IntelliCenterDataInterface.cs
+++ b/IntelliCenterControl/IntelliCenterControl/Services/IntelliCenterDataInterface.cs
@@ -131,6 +131,10 @@ namespace IntelliCenterControl.Services
                                             (sender, certificate, chain, sslPolicyErrors) => true;
                                     return message;
                                 };
+                                options.WebSocketConfiguration = c =>
+                                {
+                                    c.RemoteCertificateValidationCallback = (sender, cert, chain, errors) => true;
+                                };
                             })
                             .WithAutomaticReconnect(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(20) })
                         .Build();


### PR DESCRIPTION
On another project I found I had to include this code to get web sockets working, otherwise it would fall back to server sent events.